### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ contact: chen.xin.nien@gmail.com
 
 <br/>
 <br/>
-###Install on Windows
+### Install on Windows
 install step video: https://www.youtube.com/watch?v=pM3q9udreDo
 <br/>
 <br/>
 
-###Install on Linux
-###1. must first install the MySQL and JDK8
+### Install on Linux
+### 1. must first install the MySQL and JDK8
 ```
 # apt-get install mysql-server
 # apt-get install oracle-java8-jdk
@@ -111,12 +111,12 @@ Java(TM) SE Runtime Environment (build 1.8.0-b132)
 Java HotSpot(TM) Client VM (build 25.0-b70, mixed mode)
 
 
-###config MySQL root account's password
+### config MySQL root account's password
 ```
 # mysqladmin -u root -p password
 ```
 
-###2. Config MySQL enable lower_case_table_names=1
+### 2. Config MySQL enable lower_case_table_names=1
 ```
 # service mysql stop
 # vi /etc/mysql/my.cnf
@@ -132,23 +132,23 @@ and save my.cnf
 # service mysql restart
 ```
 
-###3. Get bambooBSC environment file
+### 3. Get bambooBSC environment file
 ```
 # cd /home
 # wget --no-check-certificate https://github.com/billchen198318/bamboobsc/releases/download/v0.7.1/bamboobsc-0.7.1-RELEASE.7z
 ```
 
-###4. Install P7ZIP
+### 4. Install P7ZIP
 ```
 # apt-get install p7zip
 ```
 
-###5. Extract the archive
+### 5. Extract the archive
 ```
 # p7zip -d bamboobsc-0.7.1-RELEASE.7z
 ```
 
-###6. Import bbcore.sql to MySQL
+### 6. Import bbcore.sql to MySQL
 ```
 # cd /home/bamboobsc-07/
 # mysql -u root -p
@@ -159,7 +159,7 @@ mysql> exit;<br/>
 # mysql bbcore -u root -p < bbcore.sql
 ```
 
-###7. Config applicationContext-dataSource.properties
+### 7. Config applicationContext-dataSource.properties
 config A ( CORE system ).<br/> /home/bamboobsc-07/apache-tomcat-8.0.41/webapps/<b>core-web</b>/WEB-INF/classes/applicationContext/conf/applicationContext-dataSource.properties<br/>
 <br/>
 config B (Balanced Scorecard system ).<br/> /home/bamboobsc-07/apache-tomcat-8.0.41/webapps/<b>gsbsc-web</b>/WEB-INF/classes/applicationContext/conf/applicationContext-dataSource.properties<br/>
@@ -178,13 +178,13 @@ dataSource.user=root
 dataSource.password=password
 ```
 
-###8. The need to create the directory folder, for upload and report source file need.
+### 8. The need to create the directory folder, for upload and report source file need.
 ```
 # cd /var
 # mkdir gsbsc gsbsc/upload gsbsc/jasperreport
 ```
 
-###9. Run bambooBSC
+### 9. Run bambooBSC
 ```
 # cd /home/bamboobsc-07/apache-tomcat-8.0.41/bin
 # chmod a+x catalina.sh
@@ -207,7 +207,7 @@ the log file on /tmp/
 
 <br/>
 
-###Install on Amazon EC2 Failed to get local InetAddress for VMID
+### Install on Amazon EC2 Failed to get local InetAddress for VMID
 
 cannot connect to MySQL database<br/>
 Please refer to:<br/>
@@ -216,7 +216,7 @@ http://stackoverflow.com/questions/603351/can-we-set-easy-to-remember-hostnames-
 <br/>
 <br/>
 
-###Build development environments
+### Build development environments
 ```
 System required
 A. JDK8
@@ -224,23 +224,23 @@ B. Eclipse4 or later version
 C. Apache Tomcat8
 ```
 
-###1. Download archives file
+### 1. Download archives file
 click "Download ZIP" button<br/>
 <img src="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/BUILD_DEV_ENV/001.png"></img>
 
-###2. Unzip the archive file bamboobsc-master.zip
+### 2. Unzip the archive file bamboobsc-master.zip
 Unzip to C:\home\git\ <br/>
 <img src="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/BUILD_DEV_ENV/002.png"></img>
 
-###3. Open eclipse
+### 3. Open eclipse
 workspace dir input C:\home\git\bamboobsc-master<br/>
 <img src="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/BUILD_DEV_ENV/003.png"></img>
 
-###4. Configure eclipse
+### 4. Configure eclipse
 settings Text file encoding to UTF-8<br/>
 <img src="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/BUILD_DEV_ENV/005.png"></img>
 
-###5. Import project
+### 5. Import project
    a. core-persistence<br/>
    b. core-lib<br/>
    c. core-base<br/>
@@ -274,7 +274,7 @@ settings Text file encoding to UTF-8<br/>
    add External JARs: "core-base.jar", "gsbsc-persistence.jar" on C:\home\git\bamboobsc-master\core-export-lib\ <br/>
    <img src="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/BUILD_DEV_ENV/011.png"></img>
    
-###5. Clean Java Problems ( if found Java Problem on Markers )
+### 5. Clean Java Problems ( if found Java Problem on Markers )
    1. Clean all project 
    2. Restart
 
@@ -283,7 +283,7 @@ settings Text file encoding to UTF-8<br/>
 
 
 
-#bambooBSC development manual
+# bambooBSC development manual
 
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/01-Entity.md">01 - Entitiy</a>
 <br/>

--- a/core-doc/dev-docs/00-Catalog.md
+++ b/core-doc/dev-docs/00-Catalog.md
@@ -1,4 +1,4 @@
-#bambooBSC development manual
+# bambooBSC development manual
 
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/01-Entity.md">01 - Entitiy</a>
 <br/>

--- a/core-doc/dev-docs/01-Entity.md
+++ b/core-doc/dev-docs/01-Entity.md
@@ -1,9 +1,9 @@
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/00-Catalog.md">⌂ Catalog</a><br/>
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/02-DaoAndService.md">⇨ Next section 02-DAO and Service</a>
 
-#01 - Entitiy
+# 01 - Entitiy
 
-#Introduction
+# Introduction
 BaseValue recommend for Page view(VO) or transform (DTO) and for MyBatis custom query mapper, or page grid query.<br>
 BaseEntity recommend only for hibernate do save/update/delete.<br>
 
@@ -13,7 +13,7 @@ BaseEntity recommend only for hibernate do save/update/delete.<br>
 3. Dozer https://github.com/DozerMapper/dozer<br/>
 4. MyBatis https://github.com/mybatis/mybatis-3<br/>
 
-#Persistence entity
+# Persistence entity
 
 <br/>
 
@@ -138,7 +138,7 @@ public class BbTest extends BaseEntity<String> implements java.io.Serializable {
 <br/>
 <br/>
 
-###Persistence object (BaseEntity) must found variable field
+### Persistence object (BaseEntity) must found variable field
 
 | Name | Type |
 | --- | --- |
@@ -151,7 +151,7 @@ public class BbTest extends BaseEntity<String> implements java.io.Serializable {
 <br/>
 <br/>
 
-###Persistence object (BaseEntity) annotation
+### Persistence object (BaseEntity) annotation
 
 | Name | description | example |
 | --- | --- | --- |
@@ -163,7 +163,7 @@ if PO add the `@EntityPK` annotation, BaseService will check PK(primary key) whe
 if PO add the `@EntityUK` annotation, BaseService will check UK(unique key) when call saveObject method.<br/>
 
 
-#Value object
+# Value object
 a Value object extends BaseValue
 ```java
 package com.netsteadfast.greenstep.vo;
@@ -218,7 +218,7 @@ public class TestVO extends BaseValueObj implements java.io.Serializable {
 }
 ```	
 
-###Value object (BaseValue) must found variable field
+### Value object (BaseValue) must found variable field
 
 | Name | Type |
 | --- | --- |
@@ -228,7 +228,7 @@ BaseValue no need `cuserid, cdate, uuserid, udate` <br/>
 BaseService will convert VO(BaseValue) to PO(BaseEntity) and auto fill `cuserid,cdate,uuserid,udate` . when call saveObject method.<br/>
 BaseService will auto fill `oid` variable(PK) when call saveObject method.
 
-#Settings Mapper VO(value object) to PO(Persistence object) config xml ( Dozer )
+# Settings Mapper VO(value object) to PO(Persistence object) config xml ( Dozer )
 add dozerBeanMapping-test.xml into resource/dozer/
 
 ```xml
@@ -283,7 +283,7 @@ add dozerBeanMapping-test.xml into resource/dozer/
 <br/>
 <br/>
 
-#Options for MyBatis-3
+# Options for MyBatis-3
 ### Add BbTest.xml into /resource/mappers
 
 ```xml
@@ -338,7 +338,7 @@ add dozerBeanMapping-test.xml into resource/dozer/
 <br/>
 <br/>
 
-###Dynamic HQL from XML config
+### Dynamic HQL from XML config
 reference:<br/>
 for KPI page grid query:<br/>
 https://github.com/billchen198318/bamboobsc/blob/master/gsbsc-persistence/resource/dynamichql/BbKpi-dynamic-hql.xml

--- a/core-doc/dev-docs/02-DaoAndService.md
+++ b/core-doc/dev-docs/02-DaoAndService.md
@@ -3,9 +3,9 @@
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/03-LogicService.md">⇨ Next section 03-Logic service</a>
 
-#02 - DAO and Service
+# 02 - DAO and Service
 
-#Introduction
+# Introduction
 BaseDAO for data basic operation.<br>
 BaseService for for data basic operation package call DAO.<br>
 
@@ -15,7 +15,7 @@ BaseService for for data basic operation package call DAO.<br>
 3. Dozer https://github.com/DozerMapper/dozer<br/>
 4. MyBatis https://github.com/mybatis/mybatis-3<br/>
 
-###DAO interfaces example
+### DAO interfaces example
 ```JAVA
 package com.netsteadfast.greenstep.bsc.dao;
 
@@ -30,7 +30,7 @@ public interface ITestDAO<T extends java.io.Serializable, PK extends java.io.Ser
 }
 ```
 
-###DAO implements example
+### DAO implements example
 ```JAVA
 package com.netsteadfast.greenstep.bsc.dao.impl;
 
@@ -55,7 +55,7 @@ public class TestDAOImpl extends BaseDAO<BbTest, String> implements ITestDAO<BbT
 }
 ```
 
-###BaseDAO method description.
+### BaseDAO method description.
 
 | Name | Return | description |
 | --- | --- | --- |
@@ -97,7 +97,7 @@ public class TestDAOImpl extends BaseDAO<BbTest, String> implements ITestDAO<BbT
 <br/>
 <br/>
 
-###Service interfaces example
+### Service interfaces example
 *** The service interfaces must define two static variable, `MAPPER_ID_PO2VO` with `MAPPER_ID_VO2PO`  ***
 ```JAVA
 package com.netsteadfast.greenstep.bsc.service;
@@ -124,7 +124,7 @@ public interface ITestService<T extends java.io.Serializable, E extends java.io.
 <br/>
 <br/>
 
-###Service implements example
+### Service implements example
 
 *** Template T, E, PK ***
 
@@ -198,7 +198,7 @@ public class TestServiceImpl extends BaseService<TestVO, BbTest, String> impleme
 }
 ```
 
-###BaseService method description.
+### BaseService method description.
 
 | Name | Return | description |
 | --- | --- | --- |
@@ -299,7 +299,7 @@ Map<String, Object> queryParam = super.getQueryParamHandler(searchValue)
 <br/>
 <br/>
 
-###Config bean settings
+### Config bean settings
 add applicationContext-test.xml into /resource/applicationContext/bsc/standard/
 ```XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -324,7 +324,7 @@ add applicationContext-test.xml into /resource/applicationContext/bsc/standard/
 <br/>
 <br/>
 
-###Config add resource xml
+### Config add resource xml
 Edit config applicationContext-BSC-STANDARD-BEANS.xml add item
 ```XML
 <import resource="classpath*:applicationContext/bsc/standard/applicationContext-test.xml" />
@@ -334,7 +334,7 @@ Edit config applicationContext-BSC-STANDARD-BEANS.xml add item
 <br/>
 <br/>
 
-###Page grid query example code ( for Dynamic HQL from XML config )
+### Page grid query example code ( for Dynamic HQL from XML config )
 reference:<br/>
 Dynamic HQL XML config:<br/>
 https://github.com/billchen198318/bamboobsc/blob/master/gsbsc-persistence/resource/dynamichql/BbVision-dynamic-hql.xml<br/>

--- a/core-doc/dev-docs/03-LogicService.md
+++ b/core-doc/dev-docs/03-LogicService.md
@@ -4,8 +4,8 @@
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/04-ControllerAction.md">⇨ Next section 04-Controller</a>
 
 
-#03 - Logic service
-#Introduction
+# 03 - Logic service
+# Introduction
 Logic service is do many base-service with complicated transaction script bean service.<br>
 
 
@@ -16,7 +16,7 @@ Logic service is do many base-service with complicated transaction script bean s
 4. MyBatis https://github.com/mybatis/mybatis-3<br/>
 5. Activiti BPMN http://activiti.org/<br/>
 
-###BaseLogicService
+### BaseLogicService
 BaseLogicService is minimum unit Logic Service, it main support CORE-SYSTEM used.
 
 
@@ -37,7 +37,7 @@ https://github.com/billchen198318/bamboobsc/blob/master/core-base/src/com/netste
 <br/>
 <br/>
 
-###CoreBaseLogicService 
+### CoreBaseLogicService 
 CoreBaseLogicService is extends BaseLogicService, it main support GSBSC-SYSTEM, QCHARTS-SYSTEM.
 
 | Name | Return | description |
@@ -57,7 +57,7 @@ https://github.com/billchen198318/bamboobsc/blob/master/qcharts-standard/src/com
 <br/>
 <br/>
 
-###BscBaseLogicService 
+### BscBaseLogicService 
 BscBaseLogicService is extends CoreBaseLogicService, it main support GSBSC-SYSTEM.
 
 | Name | Return | description |
@@ -79,7 +79,7 @@ https://github.com/billchen198318/bamboobsc/blob/master/gsbsc-standard/src/com/n
 <br/>
 
 
-###BscBaseBusinessProcessManagementLogicService 
+### BscBaseBusinessProcessManagementLogicService 
 BscBaseBusinessProcessManagementLogicService is extends CoreBaseLogicService and BusinessProcessManagementBaseLogicService.<br/> 
 BscBaseBusinessProcessManagementLogicService it main support GSBSC-SYSTEM with BPMN.
 
@@ -113,7 +113,7 @@ https://github.com/billchen198318/bamboobsc/blob/master/gsbsc-standard/resource/
 <br/>
 <br/>
 
-###Logic service Authority annotation
+### Logic service Authority annotation
 | Name | description |
 | --- | --- |
 | @ServiceAuthority | check=true this Logic service enable Authority check,  check=false disable |
@@ -132,7 +132,7 @@ https://github.com/billchen198318/bamboobsc/blob/master/gsbsc-standard/resource/
 | DELETE | method delete data mode |
 
 
-#Logic service AOP scan package config
+# Logic service AOP scan package config
 ```JAVA
 package com.netsteadfast.greenstep.aspect;
 
@@ -154,7 +154,7 @@ public class AspectConstants {
 
 
 
-#Add Logic service authority
+# Add Logic service authority
 Please use: 
 Role's permitted settings -> `01 - Role` function to add permitted value
 

--- a/core-doc/dev-docs/04-ControllerAction.md
+++ b/core-doc/dev-docs/04-ControllerAction.md
@@ -4,8 +4,8 @@
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/05-ProgramRegistrationAndMenuSettings.md">⇨ Next section 05-Program registration and Menu settings</a>
 
 
-#04 - Controller
-#Introduction
+# 04 - Controller
+# Introduction
 bambooBSC page view / controller is use JSP / Struts2 and DOJO.<br>
 
 
@@ -14,7 +14,7 @@ bambooBSC page view / controller is use JSP / Struts2 and DOJO.<br>
 2. Struts2 https://struts.apache.org/docs/home.html<br/>
 3. DOJO javascript framework https://dojotoolkit.org/<br/>
 
-#BaseSupportAction
+# BaseSupportAction
 BaseSupportAction is for default page action, usually use of Management page, Edit page, Create page.<br/>
 
 | Name | Return | description |
@@ -61,7 +61,7 @@ BaseSupportAction is for default page action, usually use of Management page, Ed
 | isNoSelectId(String value) | boolean | if no select options item return true |
 | transformAppendIds2ListByEncode(String appendIds)<br/><br/>transformAppendIds2List(String appendIds)<br/><br/>joinAppend2String(List`<String>` datas) | String | for text work |
 
-#IBaseAdditionalSupportAction interfaces
+# IBaseAdditionalSupportAction interfaces
 The IBaseAdditionalSupportAction interfaces support View Page( JSP ) to get action method program-id and program-name.
 ```JAVA
 @Override
@@ -90,7 +90,7 @@ JSP code for IBaseAdditionalSupportAction show head label.
 <br/>
 <br/>
 
-#BaseJsonAction
+# BaseJsonAction
 BaseJsonAction is extends BaseSupportAction, it is for Save/Update/Delete controller action use.
 
 | Name | Return | description |
@@ -105,7 +105,7 @@ BaseJsonAction is extends BaseSupportAction, it is for Save/Update/Delete contro
 
 <br/>
 <br/>
-#BaseQueryGridJsonAction
+# BaseQueryGridJsonAction
 BaseQueryGridJsonAction is extends BaseJsonAction, it main support Grid query.
 
 | Name | Return | description |
@@ -118,7 +118,7 @@ BaseQueryGridJsonAction is extends BaseJsonAction, it main support Grid query.
 
 <br/>
 <br/>
-#Controller annotation
+# Controller annotation
 
 | Name | description |
 | --- | --- |
@@ -138,7 +138,7 @@ Program id naming rules example:
 <br/>
 <br/>
 
-#Program page show at DOJO-Tab javascript
+# Program page show at DOJO-Tab javascript
 Show at DOJO-Tab javascript function system auto generated when the program has registered.
 
 | function-key | description |
@@ -168,7 +168,7 @@ Example:
 <br/>
 <br/>
 
-#GreenStep page Tag
+# GreenStep page Tag
 The gs tag is work with Struts2 and DOJO javascript.
 
 | Tag | description |
@@ -377,7 +377,7 @@ function BSC_PROG002D0001Q_GridButtonClick(itemOid) {
 <br/>
 <br/>
 
-#Page common javascript function
+# Page common javascript function
 
 | Name | return | description |
 | --- | --- | --- |
@@ -413,7 +413,7 @@ other:<br/>
 `setPageOfOrderBy(_id, queryFieldName)`<br/>
 `getGoogleMapAddressName(lat, lng, _setAddressFn)`<br/>
 
-#Add controller to menu item and config authority
+# Add controller to menu item and config authority
 Please use:
 <br/> 
 1. Registration use `02 - Program registration` to add.<br/> 
@@ -423,7 +423,7 @@ Please use:
 <br/>
 <br/>
 
-#reference example:
+# reference example:
 Management query action:<br>
 https://github.com/billchen198318/bamboobsc/blob/master/gsbsc-web/src/com/netsteadfast/greenstep/bsc/action/VisionManagementAction.java<br/><br>
 Grid query action:<br/>

--- a/core-doc/dev-docs/05-ProgramRegistrationAndMenuSettings.md
+++ b/core-doc/dev-docs/05-ProgramRegistrationAndMenuSettings.md
@@ -4,12 +4,12 @@
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/06-RoleAndAuthoritySettings.md">⇨ Next section 06-Role and authority settings</a>
 
 
-#05 - Program registration and Menu settings
-#Introduction
+# 05 - Program registration and Menu settings
+# Introduction
 bambooBSC registration controller action url into menu.<br>
 
 
-#Program registration
+# Program registration
 
 1. click `02 - Program registration`
 ![Image of prgoram-reg](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/05-001.jpg)
@@ -21,7 +21,7 @@ bambooBSC registration controller action url into menu.<br>
 <br/>
 ***After this setting save/update must have to refresh bambooBSC page to take effect.***
 
-#Menu settings
+# Menu settings
 
 1. click `03 - Menu settings` to management
 ![Image of menu-settings](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/05-003.jpg)

--- a/core-doc/dev-docs/06-RoleAndAuthoritySettings.md
+++ b/core-doc/dev-docs/06-RoleAndAuthoritySettings.md
@@ -4,8 +4,8 @@
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/07-ExpressionSupportLogicService.md">⇨ Next section 07-Expression support LogicService</a>
 
 
-#06 - Role and authority settings 
-#Introduction
+# 06 - Role and authority settings 
+# Introduction
 bambooBSC role and authority settings.<br>
 
 **super role no need do all settings, it can use all function and view all menu-item.**
@@ -26,7 +26,7 @@ Parameter config:
 select PARAM1 from tb_sys_code where CODE='BSC_CONF001'
 ```
 
-#Role management
+# Role management
 
 1. click `01 - Role`
 ![Image of Role-mgr1](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/06-001.jpg)
@@ -34,7 +34,7 @@ select PARAM1 from tb_sys_code where CODE='BSC_CONF001'
 <br/>
 ***`admin` and * Role is super role, super role cannot share copy as***
 
-#Role's permitted settings 
+# Role's permitted settings 
 
 ![Image of Role-mgr2](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/06-002.jpg)
 <br/>
@@ -42,13 +42,13 @@ select PARAM1 from tb_sys_code where CODE='BSC_CONF001'
 ***`admin` and * Role is super role, super role no need permitted settings, super role can use all function***
 
 
-#Config user role
+# Config user role
 1. click `02 - User's role` to settings
 ![Image of Role-mgr3](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/06-003.jpg)
 <br/>
 <br/>
 
-#Config menu item role
+# Config menu item role
 1. click `03 - Role for program (menu) ` to settings
 ![Image of Role-mgr4](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/06-004.jpg)
 <br/>

--- a/core-doc/dev-docs/07-ExpressionSupportLogicService.md
+++ b/core-doc/dev-docs/07-ExpressionSupportLogicService.md
@@ -5,8 +5,8 @@ Previous section 06 - Role and authority settings</a>
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/08-WebService.md">⇨ 
 Next section 08 - WebService</a>
 
-#07 - Expression support Logic Service
-#Introduction
+# 07 - Expression support Logic Service
+# Introduction
 bambooBSC expression.<br>
 我想也不會有人想看吧，所以直接用中文寫好了。<br/>
 **注意: 錯誤的 expression 都有可能造成系統崩潰，所以必須要有良好的經驗，在來使用這個功能**<br/>
@@ -20,7 +20,7 @@ bambooBSC expression.<br>
 2. BeanShell http://www.beanshell.org/intro.html
 
 
-#Create Expression for Logic Service bean
+# Create Expression for Logic Service bean
 使用 `02 - Expression` 去創建一個expression，這個 expression 必須能與被輔助的 Service Logic bean's method 配合<br/>
 <br/>
 ![Image of expr-mgr1](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/07-001.jpg)
@@ -32,7 +32,7 @@ bambooBSC expression.<br>
 <br/>
 <br/>
 
-#Create expression support Logic Service settings
+# Create expression support Logic Service settings
 創建設定<br/>
 ![Image of expr-mgr3](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/07-003.jpg)
 <br/>
@@ -54,7 +54,7 @@ bambooBSC expression.<br>
 **以上步驟設定完後，每次被設的的 LogicService method 觸發時，AOP ( ServiceScriptExpressionProcessAspect ) 都會去調用執行設定的 Expression**
 
 
-###ServiceScriptExpressionUtils only for ServiceScriptExpressionProcessAspect 
+### ServiceScriptExpressionUtils only for ServiceScriptExpressionProcessAspect 
 
 | Name | return |description |
 | --- | --- | --- |
@@ -66,7 +66,7 @@ bambooBSC expression.<br>
 <br/>
 <br/>
 
-###ScriptExpressionUtils
+### ScriptExpressionUtils
 | Name | return |description |
 | --- | --- | --- |
 | execute(String type, String scriptExpression, `Map<String, Object>` results, `Map<String, Object>` parameters) | `Map<String, Object>` | run expression, type has BSH, GROOVY, PYTHON |

--- a/core-doc/dev-docs/08-WebService.md
+++ b/core-doc/dev-docs/08-WebService.md
@@ -4,8 +4,8 @@
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/09-JasperReport.md"> ⇨ Next section 09 -  JasperReport</a>
 
 
-#08 - WebService
-#Introduction
+# 08 - WebService
+# Introduction
 bambooBSC public a SOAP / REST.<br>
 
 
@@ -14,7 +14,7 @@ bambooBSC public a SOAP / REST.<br>
 2. Apache CXF http://cxf.apache.org/<br/>
 3. Apache Camel http://camel.apache.org/examples.html
 
-###SOAP
+### SOAP
 Example for SOAP:
 
 **Service interfaces**
@@ -71,7 +71,7 @@ public class KpiWebServiceImpl implements KpiWebService {
 <bean id="bsc.webservice.KpiWebService" class="com.netsteadfast.greenstep.bsc.webservice.impl.KpiWebServiceImpl" />
 ```
 
-#REST
+# REST
 Example for REST:
 
 ```JAVA
@@ -118,7 +118,7 @@ public class KpiLogicServiceImpl extends BscBaseLogicService implements IKpiLogi
 }
 ```
 
-#Public the service
+# Public the service
 
 click `01 - WebService registration` to management
 ![Image of ws-mgr1](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/08-001.jpg)
@@ -133,7 +133,7 @@ click `01 - WebService registration` to management
 <br/>
 <br/>
 
-#ESB service
+# ESB service
 Example for result out of servlet:
 
 ```JAVA
@@ -189,10 +189,10 @@ public class KPIsRouteBuilder extends RouteBuilder {
     
 ```
 
-#Hessian webService
+# Hessian webService
 client & remote service settings
 
-##1. config "web.xml"
+## 1. config "web.xml"
 <br/>
 Enable hessian servlet:
 ```XML
@@ -207,7 +207,7 @@ Enable hessian servlet:
 	</servlet-mapping> 	
 ```	
 
-##2. config "Hessian-servlet.xml"
+## 2. config "Hessian-servlet.xml"
 <br/>
 Example publish a service:
 ```XML
@@ -217,7 +217,7 @@ Example publish a service:
 </bean>
 ```
 
-##3. config "applicationContext-hessian.xml"
+## 3. config "applicationContext-hessian.xml"
 ```XML
 	<bean id="hessian.config" class="java.util.HashMap" scope="singleton" >
 		<constructor-arg>
@@ -254,7 +254,7 @@ Example publish a service:
     </bean>
 ```    
 
-##4. config "applicationContext-appSettings.properties"
+## 4. config "applicationContext-appSettings.properties"
 ```
 #######################################################
 #	for applicationContext-hessian.xml

--- a/core-doc/dev-docs/09-JasperReport.md
+++ b/core-doc/dev-docs/09-JasperReport.md
@@ -4,8 +4,8 @@
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/10-BPMN.md"> ⇨ Next section 10 - BPMN</a>
 
 
-#09 - JasperReport
-#Introduction
+# 09 - JasperReport
+# Introduction
 bambooBSC public a JasperReport.<br>
 
 
@@ -13,7 +13,7 @@ bambooBSC public a JasperReport.<br>
 1. JasperReport / iReport http://community.jaspersoft.com/<br/>
 
 
-###Report file and directory structure
+### Report file and directory structure
 Example is bambooBSC SWOT PDF report.
 
 BSC_RPT002<BR/>
@@ -23,7 +23,7 @@ BSC_RPT002<BR/>
  
 zip compression directory folder `BSC_RPT002` to `BSC_RPT002.zip`
 
-#Management and upload
+# Management and upload
 click `08 - Report management` to management
 ![Image of RPT-mgr1](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/09-001.jpg)
 <br/>
@@ -35,7 +35,7 @@ click `08 - Report management` to management
 ![Image of RPT-mgr3](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/09-003.jpg)
 <br/>
 <br/>
-#View page call show report 
+# View page call show report 
 use common javascript function to open.
 ```
 openCommonJasperReportLoadWindow( 
@@ -49,11 +49,11 @@ Example code:
 openCommonJasperReportLoadWindow( "SWOT-Report", "BSC_RPT002", "PDF", { 'reportId' : data.reportId } );
 ```
 
-#reference example:
+# reference example:
 https://github.com/billchen198318/bamboobsc/blob/master/gsbsc-web/WebContent/pages/swot/swot-management.jsp
 
 
-#JReportUtils
+# JReportUtils
 
 | Name | return |description |
 | --- | --- | --- |

--- a/core-doc/dev-docs/10-BPMN.md
+++ b/core-doc/dev-docs/10-BPMN.md
@@ -4,8 +4,8 @@
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/11-Mail.md"> ⇨ Next section 11- Mail</a>
 
 
-#10 - BPMN resource
-#Introduction
+# 10 - BPMN resource
+# Introduction
 bambooBSC deploy BPMN resource.<br>
 
 
@@ -14,7 +14,7 @@ bambooBSC deploy BPMN resource.<br>
 2. Activiti BPMN http://activiti.org/<br/>
 
 
-#Package resource file
+# Package resource file
 Example for `PDCAProjectProcess` <br/>
 PDCAProjectProcess files:<br/>
 |--PDCAProjectProcess.bpmn<br/>
@@ -22,7 +22,7 @@ PDCAProjectProcess files:<br/>
 
 zip compression PDCAProjectProcess.bpmn and PDCAProjectProcess.png to PDCAProjectProcess.zip
 
-#Upload resource and deploy
+# Upload resource and deploy
 click `04 - BPMN Resource` to management
 ![Image of BPMN-res-mgr1](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/10-001.png)
 <br/>
@@ -32,13 +32,13 @@ click `04 - BPMN Resource` to management
 <br/>
 
 
-#Settings resource audit roles
+# Settings resource audit roles
 click `05 - BPMN Resource role` to management
 ![Image of BPMN-res-mgr3](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/10-003.png)
 <br/>
 <br/>
 
-#Logic Service integrate BPMN resource example
+# Logic Service integrate BPMN resource example
 The example is PDCA Project. `getBusinessProcessManagementResourceId()` return value is deploy BPMN resource id.
 ```JAVA
 @ServiceAuthority(check=true)
@@ -69,7 +69,7 @@ https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/03-Log
 https://github.com/billchen198318/bamboobsc/blob/master/gsbsc-standard/src/com/netsteadfast/greenstep/bsc/service/logic/IPdcaLogicService.java<br/>
 https://github.com/billchen198318/bamboobsc/blob/master/gsbsc-standard/src/com/netsteadfast/greenstep/bsc/service/logic/impl/PdcaLogicServiceImpl.java
 
-#Force delete a work resource
+# Force delete a work resource
 Example:<br/>
 BusinessProcessManagementDeleteTools [true/false] [resource-Id]<br/>
 UNIX command: `delete_bpmn_res.sh true TestResourceId`<br/>

--- a/core-doc/dev-docs/11-Mail.md
+++ b/core-doc/dev-docs/11-Mail.md
@@ -7,15 +7,15 @@ Next section 12 - Job</a>
 
 
 
-#11 - Mail
-#Introduction
+# 11 - Mail
+# Introduction
 Send email method description.<br>
 
 
 ***You must first understand the following framework***<br/>
 1. Spring http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/<br/>
 
-#Use CORE-system job to send mail
+# Use CORE-system job to send mail
 it will send mail by job, and pre job max 50s mail to send, a job task wait 2 min.<br/>
 Example:
 ```JAVA
@@ -35,7 +35,7 @@ mailHelper.setSuccessFlag(YesNo.NO);
 this.sysMailHelperService.saveObject(mailHelper);
 ```
 
-#Use MailClientUtils send mail
+# Use MailClientUtils send mail
 MailClientUtils is send mail tool for bambooBSC.
 
 
@@ -55,7 +55,7 @@ MailClientUtils.send("root@localhost", "tiffany@localhost", "Test", "hello world
 ```
 
 
-#Use Spring JavaMailSender
+# Use Spring JavaMailSender
 Use JavaMailSender . <br/>
 Example:
 ```JAVA
@@ -78,7 +78,7 @@ for (int i=0; fileNames!=null && i<fileNames.length; i++) {
 mailSender.send(message);
 ```
 
-#Config for mail, applicationContext-mail.properties
+# Config for mail, applicationContext-mail.properties
 
 mail.host=localhost<br/> 
 mail.port=25<br/>

--- a/core-doc/dev-docs/12-Job.md
+++ b/core-doc/dev-docs/12-Job.md
@@ -6,8 +6,8 @@ Previous section 11 - Mail</a>
 Next section 13 - Template</a>
 
 
-#12 - Job scheduler
-#Introduction
+# 12 - Job scheduler
+# Introduction
 bambooBSC Job scheduler.<br>
 
 
@@ -15,7 +15,7 @@ bambooBSC Job scheduler.<br>
 1. Spring http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/<br/>
 2. Quartz http://www.quartz-scheduler.org/
 
-#BaseJob
+# BaseJob
 BaseJob is support Job scheduler object.<br/>
 Example:<br/>
 
@@ -77,7 +77,7 @@ protected void executeInternal(JobExecutionContext context) throws JobExecutionE
 
 
 
-#Config for Quartz with spring
+# Config for Quartz with spring
 **applicationContext-STANDARD-QUARTZ-JOB.xml**
 <br/>
 applicationContext-STANDARD-QUARTZ-JOB.xml is for Job Task config.

--- a/core-doc/dev-docs/13-Template.md
+++ b/core-doc/dev-docs/13-Template.md
@@ -6,8 +6,8 @@ Previous section 12 - Job Scheduler</a>
 Next section 14 - Web Context bean</a>
 
 
-#13 - Template
-#Introduction
+# 13 - Template
+# Introduction
 bambooBSC template model.<br>
 
 
@@ -15,7 +15,7 @@ bambooBSC template model.<br>
 1. Spring http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/<br/>
 2. Apache FreeMarker http://freemarker.org/
 
-#Create template resource
+# Create template resource
 create a template resource.
 ![Image of BPMN-res-mgr1](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/13-001.jpeg)
 <br/>
@@ -66,13 +66,13 @@ public DefaultResult<VisionVO> create(VisionVO vision) throws ServiceException, 
 }
 ```
 
-#Test result
+# Test result
 The test use sendmail to send template result content.
 ![Image of BPMN-res-mgr1](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/13-004.jpeg)
 <br/>
 <br/>
 
-#TemplateUtils
+# TemplateUtils
 TemplateUtils is bambooBSC template util.
 
 

--- a/core-doc/dev-docs/14-WebContextBean.md
+++ b/core-doc/dev-docs/14-WebContextBean.md
@@ -6,8 +6,8 @@ Previous section 13 - Template</a>
 Next section 15 - Formula</a>
 
 
-#14 - Web Context bean
-#Introduction
+# 14 - Web Context bean
+# Introduction
 server web context start or shutdown will run java class bean.<br>
 WebSystemCtxBeanSupportListener will auto create bean( ContextInitializedAndDestroyedBean ) and call `execute(ServletContextEvent event)` method for INITIALIZE or DESTROY.
 
@@ -15,7 +15,7 @@ WebSystemCtxBeanSupportListener will auto create bean( ContextInitializedAndDest
 ***You must first understand the following framework***<br/>
 1. ServletContextListener https://tomcat.apache.org/tomcat-8.0-doc/servletapi/javax/servlet/ServletContextListener.html<br/>
 
-#Create a event bean
+# Create a event bean
 The class need extends ContextInitializedAndDestroyedBean<br/>
 Example:
 ```JAVA
@@ -32,7 +32,7 @@ public class CleanTempUploadForContextInitAndDestroy extends ContextInitializedA
 }
 ```
 
-#Create config
+# Create config
 Add config item.
 ![Image of WEB-CTX-BEAN-mgr1](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/14-001.jpeg)
 <br/>
@@ -43,7 +43,7 @@ Add config item.
 
 **And need restart tomcat server to effective**
 
-#ContextInitializedAndDestroyedBean
+# ContextInitializedAndDestroyedBean
 
 | Name | return |description |
 | --- | --- | --- |

--- a/core-doc/dev-docs/15-Formula.md
+++ b/core-doc/dev-docs/15-Formula.md
@@ -5,8 +5,8 @@ Previous section 14 - Web Context bean</a>
 <a href="https://github.com/billchen198318/bamboobsc/blob/master/core-doc/dev-docs/16-API.md">⇨ 
 Next section 16 - API</a>
 
-#15 - Formula
-#Introduction
+# 15 - Formula
+# Introduction
 Management bambooBSC formula for REPORT/KPI score calculate.
 
 
@@ -15,15 +15,15 @@ Management bambooBSC formula for REPORT/KPI score calculate.
 2. GROOVY http://www.groovy-lang.org/documentation.html<br/>
 3. BeanShell http://www.beanshell.org/intro.html
 
-#Management formula or KPI aggregation method
+# Management formula or KPI aggregation method
 management aggregation method use `A. Balanced scorecard -> Basic data -> 08 - Aggregation Method`<br/>
 management formula use `A. Balanced scorecard -> Basic data -> 03 - Formula`
 
-#Formula & Aggregation method computing architecture
+# Formula & Aggregation method computing architecture
 ![Image of FORMULA-mgr1](https://raw.githubusercontent.com/billchen198318/bamboobsc/master/core-doc/dev-docs/pics/15-001.jpg)
 <br/>
 <br/>
-#BscFormulaUtils
+# BscFormulaUtils
 | Name | return |description |
 | --- | --- | --- |
 | getFormulaById(String forId) | FormulaVO | get formula data by formula-id |
@@ -33,7 +33,7 @@ management formula use `A. Balanced scorecard -> Basic data -> 03 - Formula`
 | parse(FormulaVO formula, BscMeasureData data) | Object | parse expression |
 | parseKPIPeroidScoreChangeValue(FormulaVO formula, float currentPeroidScore, float previousPeroidScore) | Object | parse expression for peroid score change |
 
-#AggregationMethodUtils
+# AggregationMethodUtils
 | Name | return |description |
 | --- | --- | --- |
 | processDefaultMode(KpiVO kpi) | float | process expression |

--- a/core-doc/dev-docs/16-API.md
+++ b/core-doc/dev-docs/16-API.md
@@ -4,32 +4,32 @@
 Previous section 15 - Formula</a>
 
 
-#16 - API (REST/SOAP) for get Scorecard
-#Introduction
+# 16 - API (REST/SOAP) for get Scorecard
+# Introduction
 bambooBSC API rest/soap for get Scorecard.
 
-###only 0.7.0-RELEASE or later version has support.
+### only 0.7.0-RELEASE or later version has support.
 
 <br/>
 <br/>
-#1. REST:
-###REST url:
+# 1. REST:
+### REST url:
 127.0.0.1:8080/gsbsc-web/services/jaxrs/scorecard1/
 
-###Example:
+### Example:
 ```
 curl -i -X GET "http://127.0.0.1:8080/gsbsc-web/services/jaxrs/scorecard1?visionOid=1089abb5-3faf-445d-88ff-cd7690ac6743&startDate=&endDate=&startYearDate=2015&endYearDate=2016&frequency=6&dataFor=all&measureDataOrganizationOid=&measureDataEmployeeOid=&contentFlag="
 ```
 <br>
 
-#2. SOAP:
-###WSDL url:
+# 2. SOAP:
+### WSDL url:
 http://127.0.0.1:8080/gsbsc-web/services/api?wsdl
-###Method:
+### Method:
 getScorecard1
 
 <br>
-###Example:
+### Example:
 
 ```XML
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:web="http://webservice.bsc.greenstep.netsteadfast.com/">
@@ -54,7 +54,7 @@ getScorecard1
 ```
 
 
-#Query parameter description
+# Query parameter description
 | Name |description |
 | --- | --- | --- |
 | visionOid | Vision PK, tb_vision.OID |
@@ -68,7 +68,7 @@ getScorecard1
 | contentFlag | if value `Y` , will put xml and json data result out |
 
 
-###Frequency value description
+### Frequency value description
 | Frequency |description | 
 | --- | --- |
 | 1 | Day |
@@ -81,9 +81,9 @@ getScorecard1
 <br/>
 <br/>
 
-#REST Result:
+# REST Result:
 
-###Example:
+### Example:
 
 ```JSON
 {
@@ -120,7 +120,7 @@ getScorecard1
 
 <br>
 
-#Result variable description
+# Result variable description
 | Name |description |
 | --- | --- | --- |
 | htmlBodyUrl | This url will print BSC report html content |


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
